### PR TITLE
Fixing getting dnascan_dir from paths_configs instead from args.

### DIFF
--- a/scripts/DNAscan
+++ b/scripts/DNAscan
@@ -478,7 +478,7 @@ RG = args.RG
 
 ref_file = args.ref_file 
 
-dnascan_main_dir = args.dnascan_dir
+dnascan_main_dir = paths_configs.dnascan_dir
 
 if ref_file:
     

--- a/scripts/DNAscan.py
+++ b/scripts/DNAscan.py
@@ -478,7 +478,7 @@ RG = args.RG
 
 ref_file = args.ref_file 
 
-dnascan_main_dir = args.dnascan_dir
+dnascan_main_dir = paths_configs.dnascan_dir
 
 if ref_file:
     


### PR DESCRIPTION
When running `DNAscan/scripts/DNAscan.py` `dnascan_dir` is not found in `args`. This gets it from `paths_configs` instead.